### PR TITLE
Let the Browser choose the protocol to get the libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,8 +51,8 @@
 	</audio>
 
 	<!-- Libs -->
-	<script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
-	<script src="http://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+	<script src="//code.jquery.com/jquery-1.10.1.min.js"></script>
+	<script src="//code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
 	<!-- Nyan Stuff -->
 	<script src="js/nyan-cat.js"></script>
 	<script src="js/nyan-sparks.js"></script>


### PR DESCRIPTION
This removes the force-use of HTTP to get jQuery from the CDN.

Every reference to other resources  should be made with "//" instead of hard-coding the protocol in it.
